### PR TITLE
WIP: Fixing the compiler warnings for GCC 11

### DIFF
--- a/nel/include/nel/misc/types_nl.h
+++ b/nel/include/nel/misc/types_nl.h
@@ -174,7 +174,7 @@
 #	define NL_COMP_GCC
 #endif
 
-#if defined(_HAS_CPP0X) || defined(__GXX_EXPERIMENTAL_CXX0X__) || (defined(NL_COMP_VC_VERSION) && NL_COMP_VC_VERSION >= 110)
+#if defined(_HAS_CPP0X) || defined(__GXX_EXPERIMENTAL_CXX0X__) || (defined(__GNUG__) && __cplusplus >= 201103L) || (defined(NL_COMP_VC_VERSION) && NL_COMP_VC_VERSION >= 110)
 #	define NL_ISO_CPP0X_AVAILABLE
 #endif
 
@@ -515,7 +515,12 @@ extern void operator delete[](void *p) throw();
 #	define CHashMap ::__gnu_cxx::hash_map
 #	define CHashSet ::__gnu_cxx::hash_set
 #	define CHashMultiMap ::__gnu_cxx::hash_multimap
-#	define CUniquePtr ::std::auto_ptr
+// From GCC 4.4 onward std:unique_ptr should be available in std library. It's deprectated later on
+#	if GCC_VERSION > 40400
+#		define CUniquePtr ::std::unique_ptr
+#	else
+#		define CUniquePtr ::std::auto_ptr
+#	endif
 #	define CUniquePtrMove
 
 namespace __gnu_cxx {

--- a/nel/tools/nel_unit_test/nel_unit_test.cpp
+++ b/nel/tools/nel_unit_test/nel_unit_test.cpp
@@ -21,6 +21,9 @@
 
 #include <nel/misc/debug.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 using namespace std;
 
 #ifdef NL_OS_WINDOWS
@@ -160,3 +163,5 @@ int main(int argc, char *argv[])
 		nlwarning("Errors during unit testing");
 	return noerrors?EXIT_SUCCESS:EXIT_FAILURE;
 }
+
+#pragma GCC diagnostic pop

--- a/nel/tools/nel_unit_test/ut_misc.h
+++ b/nel/tools/nel_unit_test/ut_misc.h
@@ -34,6 +34,9 @@
 #include "ut_misc_base64.h"
 // Add a line here when adding a new test CLASS
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 struct CUTMisc : public Test::Suite
 {
 	CUTMisc()
@@ -56,5 +59,7 @@ struct CUTMisc : public Test::Suite
 		// Add a line here when adding a new test CLASS
 	}
 };
+
+#pragma GCC diagnostic pop
 
 #endif

--- a/nel/tools/nel_unit_test/ut_net.h
+++ b/nel/tools/nel_unit_test/ut_net.h
@@ -24,6 +24,9 @@
 #include "ut_net_module.h"
 // Add a line here when adding a new test CLASS
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 struct CUTNet : public Test::Suite
 {
 	CUTNet()
@@ -34,5 +37,7 @@ struct CUTNet : public Test::Suite
 		// Add a line here when adding a new test CLASS
 	}
 };
+
+#pragma GCC diagnostic pop
 
 #endif


### PR DESCRIPTION
This PR is supposed to be amended by further commits targeting further warnings as by issue #646 

Fix: [linux] Silence warnings about deprecated use of std::auto_ptr. Use std::unique_ptr for GCC > 4.4