### PR TITLE
add missing import

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,6 +160,10 @@ jobs:
         sudo mv msquic.h /usr/include/msquic.h
         sudo mv msquic_posix.h /usr/include/msquic_posix.h
         sudo mv quic_sal_stub.h /usr/include/quic_sal_stub.h
+        wget --output-document=/tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v3.27.9/cmake-3.27.9-linux-x86_64.sh
+        sudo mkdir /opt/cmake
+        sudo sh /tmp/cmake.sh --skip-license --prefix=/opt/cmake
+        sudo ln --symbolic --force /opt/cmake/bin/cmake /usr/local/bin/cmake
       displayName: '(ubuntu) Dependencies'
       condition: eq(variables['Agent.JobName'], 'client ubuntu')
     - task: Cache@2

--- a/nel/tools/3d/tile_edit_qt/tile_rotation_dlg.h
+++ b/nel/tools/3d/tile_edit_qt/tile_rotation_dlg.h
@@ -17,6 +17,8 @@
 #ifndef TILE_ROTATIONDLG_H
 #define TILE_ROTATIONDLG_H
 
+#include <QButtonGroup>
+
 #include "ui_tile_rotation_qt.h"
 
 class CTile_rotation_dlg : public QDialog


### PR DESCRIPTION
got an error of using an incomplete type. Adding the import fixes it

```
error: invalid use of incomplete type 'class QButtonGroup'
   37 |  int getCheckedRotation() const { return rotationButtonGroup->checkedId(); }
```