### PR TITLE
use alternative monorepo cmake approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,20 +402,8 @@ IF(WITH_NEL)
   SET(NELGUI_LIBRARIES NeL::gui)
   SET(NELSOUND_LIBRARIES NeL::sound)
 
-  # wrap find_package to be able to use local projects as dependencies the same way if it where used from installation
-  set(subprojects
-          NeL
-          CACHE STRING "Subprojects to use directly from source"
-  )
-  macro(find_package)
-    IF (POLICY CMP0057)
-      cmake_policy(SET CMP0057 NEW)
-    ENDIF ()
-
-    if (NOT "${ARGV0}" IN_LIST subprojects)
-      _find_package(${ARGV})
-    endif ()
-  endmacro()
+  # allow find_package to find projects from within the mono repo
+  list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_BINARY_DIR}/nel/internal")
 ELSE()
 #  FIND_PACKAGE(NeL COMPONENTS 3d misc pacs sound nimp REQUIRED)
   FIND_PACKAGE(NeL REQUIRED)

--- a/cmake/config-internal.cmake.in
+++ b/cmake/config-internal.cmake.in
@@ -1,0 +1,19 @@
+@PACKAGE_INIT@
+
+set(_@PROJECT_NAME@_supported_components @package_components@)
+
+foreach(_comp ${@PROJECT_NAME@_FIND_COMPONENTS})
+  if (NOT _comp IN_LIST _@PROJECT_NAME@_supported_components)
+    set(@PROJECT_NAME@_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
+  else ()
+    set(@PROJECT_NAME@_${_comp}_FOUND TRUE)
+  endif()
+endforeach()
+
+
+check_required_components(@PROJECT_NAME@)
+
+include(CMakeFindDependencyMacro)
+foreach(_dependency IN ITEMS @package_required_dependencies@)
+    find_dependency(${_dependency} REQUIRED)
+endforeach()

--- a/nel/CMakeLists.txt
+++ b/nel/CMakeLists.txt
@@ -89,28 +89,40 @@ ADD_SUBDIRECTORY(tools)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-IF(WITH_INSTALL_LIBRARIES)
-  set(project_namespace "${PROJECT_NAME}")
-  set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-  set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
-  set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
-  set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
-  set(package_components 3d georges gui ligo misc net pacs sevenzip sound snd_lowlevel) # TODO append in components to have actual list of build targets
-  set(package_required_dependencies CURL Freetype)
+set(project_namespace "${PROJECT_NAME}")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(package_components 3d georges gui ligo misc net pacs sevenzip sound snd_lowlevel) # TODO append in components to have actual list of build targets
+set(package_required_dependencies CURL Freetype)
 
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+write_basic_package_version_file(
+        "${version_config}"
+        COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file("../cmake/config.cmake.in"
+        "${project_config}"
+        INSTALL_DESTINATION "${config_install_dir}"
+)
+
+write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/internal/${PROJECT_NAME}ConfigVersion.cmake"
+        COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file("../cmake/config-internal.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/internal/${PROJECT_NAME}Config.cmake"
+        INSTALL_DESTINATION "${config_install_dir}"
+)
+
+IF(WITH_INSTALL_LIBRARIES)
   install(EXPORT "${project_export_name}"
           COMPONENT libraries
           NAMESPACE "${project_namespace}::"
           DESTINATION "${config_install_dir}"
-  )
-
-  write_basic_package_version_file(
-          "${version_config}" COMPATIBILITY SameMajorVersion
-  )
-
-  configure_package_config_file("../cmake/config.cmake.in"
-          "${project_config}"
-          INSTALL_DESTINATION "${config_install_dir}"
   )
 
   install(FILES "${project_config}" "${version_config}"


### PR DESCRIPTION
use alternative monorepo cmake approach in order to remove the need for a macro wrapping find_package